### PR TITLE
Revert "Fixed compiler warnings"

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -11,10 +11,10 @@ pub const BOOT_GDT_MAX: u64 = 3;
 pub const BOOT_PML4: u64 = 0x10000;
 pub const BOOT_PDPTE: u64 = 0x11000;
 pub const BOOT_PDE: u64 = 0x12000;
-pub const EFER_SCE: u64 = 1 << 0; /* System Call Extensions */
-pub const EFER_LME: u64 = 1 << 8; /* Long mode enable */
-pub const EFER_LMA: u64 = 1 << 10; /* Long mode active (read-only) */
-pub const EFER_NXE: u64 = 1 << 11; /* PTE No-Execute bit enable */
+pub const EFER_SCE: u64 = (1 << 0); /* System Call Extensions */
+pub const EFER_LME: u64 = (1 << 8); /* Long mode enable */
+pub const EFER_LMA: u64 = (1 << 10); /* Long mode active (read-only) */
+pub const EFER_NXE: u64 = (1 << 11); /* PTE No-Execute bit enable */
 pub const COM_PORT: u16 = 0x3f8;
 pub const SHUTDOWN_PORT: u16 = 0xf4;
 pub const PIC_MASTER_PORT: u16 = 0x20;
@@ -23,9 +23,9 @@ pub const PIC_SLAVE_PORT: u16 = 0xA0;
 /*
  * Intel long mode page directory/table entries
  */
-pub const X86_PDPT_P: u64 = 1u64 << 0; /* Present */
-pub const X86_PDPT_RW: u64 = 1u64 << 1; /* Writeable */
-pub const X86_PDPT_US: u64 = 1u64 << 2; /* User/supervisor */
-pub const X86_PDPT_PS: u64 = 1u64 << 7; /* Page size */
+pub const X86_PDPT_P: u64 = (1u64 << 0); /* Present */
+pub const X86_PDPT_RW: u64 = (1u64 << 1); /* Writeable */
+pub const X86_PDPT_US: u64 = (1u64 << 2); /* User/supervisor */
+pub const X86_PDPT_PS: u64 = (1u64 << 7); /* Page size */
 
 pub const GUEST_PAGE_SIZE: u64 = 0x200000; /* 2 MB pages in guest */

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::convert::From;
 use std::{fmt, result};
 #[cfg(target_os = "macos")]
 use xhypervisor;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -72,11 +72,11 @@ pub trait VirtualCPU {
 
 // Constructor for a conventional segment GDT (or LDT) entry
 fn create_gdt_entry(flags: u64, base: u64, limit: u64) -> u64 {
-	(base & 0xff000000u64) << (56 - 24)
+	(((base & 0xff000000u64) << (56 - 24))
 		| ((flags & 0x0000f0ffu64) << 40)
 		| ((limit & 0x000f0000u64) << (48 - 16))
 		| ((base & 0x00ffffffu64) << 16)
-		| (limit & 0x0000ffffu64)
+		| (limit & 0x0000ffffu64))
 }
 
 pub trait Vm {


### PR DESCRIPTION
This reverts commit f983acd7ba8dc4dacdffc5d0659846b7dbe2677a.