### PR TITLE
Fix GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,12 +35,12 @@ jobs:
 
 
     steps:
-    - uses: hecrj/setup-rust-action@v1.2.3
-      with: 
+    - uses: hecrj/setup-rust-action@v1
+      with:
          rust-version: ${{ matrix.rust }}
          components: ${{ matrix.components || '' }}
          targets: ${{ matrix.targets || '' }}
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
       with:
          submodules: true
     - name: Check Cargo availability

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -33,12 +33,12 @@ jobs:
 
 
     steps:
-    - uses: hecrj/setup-rust-action@v1.2.3
-      with: 
+    - uses: hecrj/setup-rust-action@v1
+      with:
          rust-version: ${{ matrix.rust }}
          components: ${{ matrix.components || '' }}
          targets: ${{ matrix.targets || '' }}
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@master
       with:
          submodules: true
     - name: Check Cargo availability


### PR DESCRIPTION
Hopefully fixes the `Failed to download action 'https://api.github.com/repos/hecrj/setup-rust-action/tarball/v1.2.3'. Error Response status code does not indicate success: 500 (Internal Server Error).` Error...