### PR TITLE
Emulate Local Apic on Windows

### DIFF
--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -226,7 +226,9 @@ impl VirtualCPU for EhyveCPU {
 						return Ok(addr[0]);
 					}
 					_ => {
-						self.io_exit(port, std::str::from_utf8(addr).unwrap().to_string())?;
+						self.io_exit(port, std::str::from_utf8(addr)
+						.or_else(|_| -> std::result::Result<&str, std::str::Utf8Error> { error!("received invalid UTF8-Char on COM1"); Ok(&"")})
+						.unwrap().to_string())?;
 					}
 				},
 				_ => {

--- a/src/linux/vcpu.rs
+++ b/src/linux/vcpu.rs
@@ -226,9 +226,16 @@ impl VirtualCPU for EhyveCPU {
 						return Ok(addr[0]);
 					}
 					_ => {
-						self.io_exit(port, std::str::from_utf8(addr)
-						.or_else(|_| -> std::result::Result<&str, std::str::Utf8Error> { error!("received invalid UTF8-Char on COM1"); Ok(&"")})
-						.unwrap().to_string())?;
+						self.io_exit(
+							port,
+							std::str::from_utf8(addr)
+								.or_else(|_| -> std::result::Result<&str, std::str::Utf8Error> {
+									error!("received invalid UTF8-Char on COM1");
+									Ok(&"")
+								})
+								.unwrap()
+								.to_string(),
+						)?;
 					}
 				},
 				_ => {

--- a/src/windows/ehyve.rs
+++ b/src/windows/ehyve.rs
@@ -158,6 +158,27 @@ impl Ehyve {
 			.set_property_cpuid_results(&cpuid_results)
 			.unwrap();
 
+		// check if Local Apic Emulation supported
+		let has_local_apic_emulation = {
+			let capability =
+				get_capability(WHV_CAPABILITY_CODE::WHvCapabilityCodeFeatures).unwrap();
+			let features = unsafe { capability.Features };
+			features.LocalApicEmulation() != 0
+		};
+
+		// enable Local Apic Emulation
+		if has_local_apic_emulation { 
+			let mut property: WHV_PARTITION_PROPERTY = unsafe { std::mem::zeroed() };
+			property.LocalApicEmulationMode =
+				platform::WHV_X64_LOCAL_APIC_EMULATION_MODE::WHvX64LocalApicEmulationModeXApic;
+	
+			partition.set_property(
+				WHV_PARTITION_PROPERTY_CODE::WHvPartitionPropertyCodeLocalApicEmulationMode,
+				&property,
+			)
+			.unwrap();
+		};
+
 		partition.setup().unwrap();
 	}
 }

--- a/src/windows/ehyve.rs
+++ b/src/windows/ehyve.rs
@@ -167,16 +167,17 @@ impl Ehyve {
 		};
 
 		// enable Local Apic Emulation
-		if has_local_apic_emulation { 
+		if has_local_apic_emulation {
 			let mut property: WHV_PARTITION_PROPERTY = unsafe { std::mem::zeroed() };
 			property.LocalApicEmulationMode =
 				platform::WHV_X64_LOCAL_APIC_EMULATION_MODE::WHvX64LocalApicEmulationModeXApic;
-	
-			partition.set_property(
-				WHV_PARTITION_PROPERTY_CODE::WHvPartitionPropertyCodeLocalApicEmulationMode,
-				&property,
-			)
-			.unwrap();
+
+			partition
+				.set_property(
+					WHV_PARTITION_PROPERTY_CODE::WHvPartitionPropertyCodeLocalApicEmulationMode,
+					&property,
+				)
+				.unwrap();
 		};
 
 		partition.setup().unwrap();

--- a/src/windows/vcpu.rs
+++ b/src/windows/vcpu.rs
@@ -320,7 +320,10 @@ impl EmulatorCallbacks for EhyveCPU {
 						&io_access.Data as *const _ as *const u8,
 						io_access.AccessSize as usize,
 					))
-					.or_else(|_| -> std::result::Result<&str, std::str::Utf8Error> { error!("received invalid UTF8-Char on COM1"); Ok(&"")})
+					.or_else(|_| -> std::result::Result<&str, std::str::Utf8Error> {
+						error!("received invalid UTF8-Char on COM1");
+						Ok(&"")
+					})
 					.unwrap()
 				};
 

--- a/src/windows/vcpu.rs
+++ b/src/windows/vcpu.rs
@@ -320,6 +320,7 @@ impl EmulatorCallbacks for EhyveCPU {
 						&io_access.Data as *const _ as *const u8,
 						io_access.AccessSize as usize,
 					))
+					.or_else(|_| -> std::result::Result<&str, std::str::Utf8Error> { error!("received invalid UTF8-Char on COM1"); Ok(&"")})
 					.unwrap()
 				};
 


### PR DESCRIPTION
Since 8254 PIT and 8259 PIC won't be emulated with the Windows
Hypervisor Platform, use Local Apic and LVTTimer of Apic instead