### PR TITLE
switch to Clap 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,20 +4,11 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -63,22 +54,44 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
 name = "ehyve"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "clap",
  "elf",
@@ -105,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "c90bf5f19754d10198ccb95b70664fc925bd1fc090a0fd9a6ebc54acc8cd6272"
 dependencies = [
  "atty",
  "humantime",
@@ -115,6 +128,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -159,9 +178,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libwhp"
@@ -199,28 +218,64 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.40"
+name = "once_cell"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "raw-cpuid"
-version = "10.3.0"
+version = "10.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738bc47119e3eeccc7e94c4a506901aea5e7b4944ecd0829cbebf4af04ceda12"
+checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
 dependencies = [
  "bitflags",
 ]
@@ -244,15 +299,15 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -269,28 +324,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -299,27 +345,21 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733537bded03aaa93543f785ae997727b30d1d9f4a03b7861d23290474242e11"
+checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ehyve"
-version = "0.0.13"
+version = "0.0.14"
 authors = ["Stefan Lankes <slankes@eonerc.rwth-aachen>"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-clap = "2.34"
+clap = { version = "4.0", features = ["derive", "cargo"] }
 elf = "0.0.10"
 env_logger = "0.9"
 lazy_static = "1.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,12 +36,32 @@ mod vm;
 #[cfg(target_os = "windows")]
 mod windows;
 
-use clap::{App, Arg};
+use clap::Parser;
 use consts::*;
 use std::env;
 use std::sync::Arc;
 use std::thread;
 use vm::*;
+
+/// A minimal hypervisor for eduOS-rs
+#[derive(Parser, Debug)]
+#[command(author=crate_authors!(), version, about, long_about = None)]
+struct Args {
+    /// Map file into the address space of the guest
+    #[arg(short, long)]
+    file: Option<String>,
+
+    /// Memory size of the guest
+    #[arg(short, long, default_value_t = DEFAULT_GUEST_SIZE)]
+    mem_size: usize,
+
+    /// Number of guest processors
+    #[arg(short, long, default_value_t = 1)]
+    num_cpus: u32,
+
+    /// Expected path to the kernel
+    path: String,
+}
 
 pub fn parse_bool(name: &str, default: bool) -> bool {
 	env::var(name)
@@ -51,55 +71,11 @@ pub fn parse_bool(name: &str, default: bool) -> bool {
 
 fn main() {
 	env_logger::init();
-
-	let matches = App::new("eHyve")
-		.version(crate_version!())
-		.author("Stefan Lankes <slankes@eonerc.rwth-aachen.de>")
-		.about("A minimal hypervisor for eduOS-rs")
-		.arg(
-			Arg::with_name("FILE")
-				.short("f")
-				.long("file")
-				.value_name("FILE")
-				.help("Map FILE into the address space of the guest")
-				.takes_value(true),
-		)
-		.arg(
-			Arg::with_name("MEM")
-				.short("m")
-				.long("memsize")
-				.value_name("MEM")
-				.help("Memory size of the guest")
-				.takes_value(true),
-		)
-		.arg(
-			Arg::with_name("CPUS")
-				.short("c")
-				.long("cpus")
-				.value_name("CPUS")
-				.help("Number of guest processors")
-				.takes_value(true),
-		)
-		.arg(
-			Arg::with_name("KERNEL")
-				.help("Sets path to the kernel")
-				.required(true)
-				.index(1),
-		)
-		.get_matches();
-
-	let path = matches
-		.value_of("KERNEL")
-		.expect("Expect path to the kernel!");
-	let file = matches.value_of("FILE").map(str::to_string);
-	let mem_size: usize = matches
-		.value_of("MEM")
-		.map(|x| utils::parse_mem(&x).expect("couldn't parse --memsize"))
-		.unwrap_or(DEFAULT_GUEST_SIZE);
-	let num_cpus: u32 = matches
-		.value_of("CPUS")
-		.map(|x| utils::parse_u32(&x).unwrap_or(1))
-		.unwrap_or(1);
+    let args = Args::parse();
+    let path = args.path;
+	let file = args.file;
+	let mem_size = args.mem_size;
+	let num_cpus = args.num_cpus;
 
 	let mut vm = create_vm(path.to_string(), VmParameter::new(mem_size, num_cpus, file)).unwrap();
 	let num_cpus = vm.num_cpus();

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,20 +47,20 @@ use vm::*;
 #[derive(Parser, Debug)]
 #[command(author=crate_authors!(), version, about, long_about = None)]
 struct Args {
-    /// Map file into the address space of the guest
-    #[arg(short, long)]
-    file: Option<String>,
+	/// Map file into the address space of the guest
+	#[arg(short, long)]
+	file: Option<String>,
 
-    /// Memory size of the guest
-    #[arg(short, long, default_value_t = DEFAULT_GUEST_SIZE)]
-    mem_size: usize,
+	/// Memory size of the guest
+	#[arg(short, long, default_value_t = DEFAULT_GUEST_SIZE)]
+	mem_size: usize,
 
-    /// Number of guest processors
-    #[arg(short, long, default_value_t = 1)]
-    num_cpus: u32,
+	/// Number of guest processors
+	#[arg(short, long, default_value_t = 1)]
+	num_cpus: u32,
 
-    /// Expected path to the kernel
-    path: String,
+	/// Expected path to the kernel
+	path: String,
 }
 
 pub fn parse_bool(name: &str, default: bool) -> bool {
@@ -71,8 +71,8 @@ pub fn parse_bool(name: &str, default: bool) -> bool {
 
 fn main() {
 	env_logger::init();
-    let args = Args::parse();
-    let path = args.path;
+	let args = Args::parse();
+	let path = args.path;
 	let file = args.file;
 	let mem_size = args.mem_size;
 	let num_cpus = args.num_cpus;


### PR DESCRIPTION
The latest version of clap doesn't use ansi_term, which is unmaintained.